### PR TITLE
Add conditional CSS to compensate for Firefox line-height bug

### DIFF
--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -83,6 +83,9 @@ module.exports = {
     paddingLeft: defaultTheme.spacing[3],
     fontSize: defaultTheme.fontSize.base,
     lineHeight: defaultTheme.lineHeight.normal,
+    '@supports (-moz-appearance: none)': {
+      lineHeight: `calc(${defaultTheme.lineHeight.normal}em - 2px)`, // Compensate for extra 2px of height that comes from nowhere in FireFox
+    },
     backgroundPosition: `right ${defaultTheme.spacing[2]} center`,
     backgroundSize: `1.5em 1.5em`,
     iconColor: defaultTheme.colors.gray[500],

--- a/src/defaultOptions.js
+++ b/src/defaultOptions.js
@@ -83,9 +83,6 @@ module.exports = {
     paddingLeft: defaultTheme.spacing[3],
     fontSize: defaultTheme.fontSize.base,
     lineHeight: defaultTheme.lineHeight.normal,
-    '@supports (-moz-appearance: none)': {
-      lineHeight: `calc(${defaultTheme.lineHeight.normal}em - 2px)`, // Compensate for extra 2px of height that comes from nowhere in FireFox
-    },
     backgroundPosition: `right ${defaultTheme.spacing[2]} center`,
     backgroundSize: `1.5em 1.5em`,
     iconColor: defaultTheme.colors.gray[500],


### PR DESCRIPTION
Firefox renders the bounding box of the text content of select elements with an additional 2px of height for some bizarre reason. For example, if you say `line-height: 20px`, the actual height will be 22px. No other browser does this.

This PR adds a `@supports` condition on an arbitrary Firefox-only CSS property to be able to override the line-height with a `calc()` value that subtracts the extra 2px.

The most unfortunate part of this is we have to decide whether to handle this annoying crap automatically for anyone who overrides the lineHeight on their select elements, or if we should just document the issue and have people account for it themselves if they want to change the line-height.

This PR currently handles it automatically but I admit it feels like a bit of an overreach, as there's no way to opt-out of it if someone wanted to for whatever reason. The code to handle it is also unpleasant 😬 